### PR TITLE
Add a case sensitive notice in the patcher.

### DIFF
--- a/patcher.py
+++ b/patcher.py
@@ -60,7 +60,7 @@ else:
     if os.path.isdir('AM2R_11'):
         print("AM2R_11 found! Copying to " + output)
     else:
-        print("AM2R_11 not found. Place AM2R_11.zip in this folder and try again.")
+        print("AM2R_11 not found. Place AM2R_11.zip (case sensitive) in this folder and try again.")
         quit()
 
 print("\nSelect your patch type:\n\n1 - Linux\n2 - Android\n\nAwaiting input:\n")


### PR DESCRIPTION
If the patcher fails to detect the zip file, there's a notice that "AM2R_11.zip" is case sensitive.