### PR TITLE
Patch openssl, add AppImage interactive option, create mesa wrapper script

### DIFF
--- a/data/mesa-wrapper.sh
+++ b/data/mesa-wrapper.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# This environment variable fixes Mesa support. If another driver is used this should not do anything.
+# See https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/4181 for more information.
+radeonsi_sync_compile="true" exec "$(dirname "$(readlink -f "$0")")/.runner-unwrapped" "$@"

--- a/patcher.sh
+++ b/patcher.sh
@@ -158,7 +158,7 @@ patch_am2r ()
 		' \;
 
 		if [ "$PATCHOPENSSL" = true ]; then
-			# GameMaker games (like AMR2) link to OpenSSL 1.0.0, which is outdated and insecure.
+			# GameMaker games (like AMR2) link to OpenSSL 1.0.0, which is outdated and deprecated.
 			# When attempting to link to newer versions, an error is raised at runtime claiming it cannot find
 			# the outdated version of OpenSSL, even though it has been patched to link to the newer version.
 			# After replacing it with libcurl, versioning is ignored, and the binary starts just fine.
@@ -379,7 +379,7 @@ main ()
 			APPIMAGE=true
 			shift # past argument
 			;;
-		--patchopenssl)
+		-l|--patchopenssl)
 			PATCHOPENSSL=true
 			shift
 			;;
@@ -396,7 +396,7 @@ main ()
 			echo -e "-m, --hqmusic\t\t\tIf provided, high quality music will be used, otherwise low quality music will be used instead."
 			echo -e "-w, --systemwide\t\tIf provided, Linux will get installed systemwide, otherwise Linux will get installed portably. Has no effect on Android."
 			echo -e "-a, --appimage\t\t\tIf provided, an AppImage will get generated, otherwise the raw binary will get generated instead. Has no effect on Android."
-			echo -e "--patchopenssl\t\t\tIf provided, the raw binary will have OpenSSL 1.0.0 patched to point to libcurl. Has no effect if the -a flag is used."
+			echo -e "-l, --patchopenssl\t\t\tIf provided, the game binary will have the deprecated OpenSSL 1.0.0 patched to point to libcurl. Has no effect for the AppImage option."
 			echo -e "-p, --prefix\t\t\tThe prefix used for patching operations. Default for systemwide is \"/usr/local\" and for non-systemwide \"<directory where this script resides>/am2r_<VersionNumber>\". As systemwide is ignored on Android, for Android this will always default to the latter option."
 			echo -e "-z, --am2rzip\t\t\tThe path to the AM2R_11 zip or directory. Default is  \"<directory where the script resides>/AM2R_11.zip\""
 			exit 0

--- a/patcher.sh
+++ b/patcher.sh
@@ -163,10 +163,10 @@ patch_am2r ()
 
 		# Currently, patchelf has a bug where this does not work correctly
 		# So it will stay commented out until it does
-		#echo "Patching insecure OpenSSL dependency with libcurl..."
-		#patchelf "$GAMEDIR/runner" \
-		#	--replace-needed "libcrypto.so.1.0.0" "libcurl.so" \
-		#	--replace-needed "libssl.so.1.0.0" "libcurl.so"
+		echo "Patching insecure OpenSSL dependency with libcurl..."
+		patchelf "$GAMEDIR/runner" \
+			--replace-needed "libcrypto.so.1.0.0" "libcurl.so" \
+			--replace-needed "libssl.so.1.0.0" "libcurl.so"
 
 		# An environment variable needs to be set on Mesa to avoid a race related to multithreaded shader compilation.
 		# To do this, we move the original executable to a hidden file, and create a bash script with the needed variable in place of the original.
@@ -311,7 +311,6 @@ main ()
 	echo "-------------------------------------------"
 
 	if (( $# <= 0 )); then
-		APPIMAGE=true
 		AM2RZIP="$SCRIPT_DIR/AM2R_11.zip"
 		local input=""
 		echo "Running in interactive mode. For a full list of arguments, run the script with \"--help\""
@@ -338,6 +337,14 @@ main ()
 		echo ""
 		if [[ "${input,,}" = "y" ]]; then
 			HQMUSIC=true
+		fi
+
+		echo "Install AM2R as AppImage?"
+		echo "[y/n]"
+		read -n1 input
+		echo ""
+		if [[ "${input,,}" = "y" ]]; then
+			APPIMAGE=true
 		fi
 
 		if [ $OSCHOICE = "linux" ]; then

--- a/patcher.sh
+++ b/patcher.sh
@@ -158,11 +158,11 @@ patch_am2r ()
 		' \;
 
 		if [ "$PATCHOPENSSL" = true ]; then
-			# GameMaker games (like AMR2) link to OpenSSL 1.0.0, which is outdated and deprecated.
+			# GameMaker games (like AMR2) link to OpenSSL 1.0.0, which is outdated and insecure.
 			# When attempting to link to newer versions, an error is raised at runtime claiming it cannot find
 			# the outdated version of OpenSSL, even though it has been patched to link to the newer version.
 			# After replacing it with libcurl, versioning is ignored, and the binary starts just fine.
-			echo "Patching insecure OpenSSL dependency with libcurl..."
+			echo "Patching deprecated OpenSSL dependency with libcurl..."
 			patchelf "$GAMEDIR/runner" \
 				--replace-needed "libcrypto.so.1.0.0" "libcurl.so" \
 				--replace-needed "libssl.so.1.0.0" "libcurl.so"
@@ -308,6 +308,7 @@ main ()
 	echo "-------------------------------------------"
 
 	if (( $# <= 0 )); then
+		APPIMAGE=true
 		AM2RZIP="$SCRIPT_DIR/AM2R_11.zip"
 		local input=""
 		echo "Running in interactive mode. For a full list of arguments, run the script with \"--help\""
@@ -334,14 +335,6 @@ main ()
 		echo ""
 		if [[ "${input,,}" = "y" ]]; then
 			HQMUSIC=true
-		fi
-
-		echo "Install AM2R as AppImage?"
-		echo "[y/n]"
-		read -n1 input
-		echo ""
-		if [[ "${input,,}" = "y" ]]; then
-			APPIMAGE=true
 		fi
 
 		if [ $OSCHOICE = "linux" ]; then

--- a/patcher.sh
+++ b/patcher.sh
@@ -168,16 +168,13 @@ patch_am2r ()
 			--replace-needed "libcrypto.so.1.0.0" "libcurl.so" \
 			--replace-needed "libssl.so.1.0.0" "libcurl.so"
 
-		# An environment variable needs to be set on Mesa to avoid a race related to multithreaded shader compilation.
-		# To do this, we move the original executable to a hidden file, and create a bash script with the needed variable in place of the original.
-		echo "Creating wrapper script to fix Mesa support..."
+		# An environment variable needs to be set on Mesa to avoid a race
+		# related to multithreaded shader compilation.  To do this, we move the
+		# original executable to a hidden file, and use a bash script with the
+		# needed variable in place of the original.
+		echo "Copying wrapper script to fix Mesa support..."
 		mv "$GAMEDIR/runner" "$GAMEDIR/.runner-unwrapped"
-		echo '
-#!/usr/bin/env bash
-# This environment variable fixes Mesa support. If another driver is used this should not do anything.
-# See https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/4181 for more information.
-radeonsi_sync_compile="true" exec "$(dirname "$(readlink -f "$0")")/.runner-unwrapped" "$@"
-' > "$GAMEDIR/runner"
+		cp "$SCRIPT_DIR/data/mesa-wrapper.sh" "$GAMEDIR/runner"
 
 		chmod +x "$GAMEDIR/runner" "$GAMEDIR/.runner-unwrapped"
 

--- a/patcher.sh
+++ b/patcher.sh
@@ -389,7 +389,7 @@ main ()
 			echo -e "-m, --hqmusic\t\t\tIf provided, high quality music will be used, otherwise low quality music will be used instead."
 			echo -e "-w, --systemwide\t\tIf provided, Linux will get installed systemwide, otherwise Linux will get installed portably. Has no effect on Android."
 			echo -e "-a, --appimage\t\t\tIf provided, an AppImage will get generated, otherwise the raw binary will get generated instead. Has no effect on Android."
-			echo -e "-l, --patchopenssl\t\t\tIf provided, the game binary will have the deprecated OpenSSL 1.0.0 patched to point to libcurl. Has no effect for the AppImage option."
+			echo -e "-l, --patchopenssl\t\t\tIf provided, the game binary will have the deprecated OpenSSL 1.0.0 dependency patched to point to libcurl. Has no effect for the AppImage option."
 			echo -e "-p, --prefix\t\t\tThe prefix used for patching operations. Default for systemwide is \"/usr/local\" and for non-systemwide \"<directory where this script resides>/am2r_<VersionNumber>\". As systemwide is ignored on Android, for Android this will always default to the latter option."
 			echo -e "-z, --am2rzip\t\t\tThe path to the AM2R_11 zip or directory. Default is  \"<directory where the script resides>/AM2R_11.zip\""
 			exit 0


### PR DESCRIPTION
This PR does the following:

1. Uncomments the portion of `patcher.sh` that patches the `runner` binary to point to `libcurl` instead of openssl 1.0.0
2. Moves the wrapper script for Mesa support into its own file
3. Adds an option in interactive mode to allow for producing the native binary instead of the AppImage

Regarding item 1, I've tested on NixOS following the installation docs in the README using `patchelf 0.15.0` and experienced no issues. I believe that the bug mentioned in previous versions of patchelf is no longer an issue.

I'm attempting to get the AM2RLauncher package working on NixOS, and these changes have allowed me to do so when pointing the launcher at my fork of this repo with these changes. Any comments/feedback would be appreciated :)