### PR TITLE
Clear X509_free symbol version info from .runner-unwrapped

### DIFF
--- a/patcher.sh
+++ b/patcher.sh
@@ -165,7 +165,8 @@ patch_am2r ()
 			echo "Patching deprecated OpenSSL dependency with libcurl..."
 			patchelf "$GAMEDIR/runner" \
 				--replace-needed "libcrypto.so.1.0.0" "libcurl.so" \
-				--replace-needed "libssl.so.1.0.0" "libcurl.so"
+				--replace-needed "libssl.so.1.0.0" "libcurl.so" \
+				--clear-symbol-version X509_free
 		fi
 
 		# An environment variable needs to be set on Mesa to avoid a race


### PR DESCRIPTION
This change clears the version requirement on the X509_free symbol linked to by the .runner-unwrapped binary via patchelf. This allows the game to run without crashing on startup when using the 64-bit 1.6 beta mod.

This change should only affect users using both the NOAPPIMAGE and PATCHOPENSSL build flags.

This change was previously discussed in https://github.com/AM2R-Community-Developers/AM2RLauncher/issues/56, and has a corresponding PR for AM2RLauncher: https://github.com/AM2R-Community-Developers/AM2RLauncher/pull/59.